### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/HTML/Strip.pm6
+++ b/lib/HTML/Strip.pm6
@@ -1,6 +1,6 @@
 use v6;
 
-module HTML::Strip;
+unit module HTML::Strip;
 use HTML::Strip::Decode;
 
 grammar HTML::Strip::Grammar {

--- a/lib/HTML/Strip/Decode.pm6
+++ b/lib/HTML/Strip/Decode.pm6
@@ -5,7 +5,7 @@
 # 
 # This library is free software; you can redistribute it and/or modify it under the same terms as Perl itself.
 
-module HTML::Strip::Decode;
+unit module HTML::Strip::Decode;
 
 my %entity2char = (
  # Some normal chars that have special meaning in SGML context


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.