### PR TITLE
Fix removed @*INC

### DIFF
--- a/t/test.t
+++ b/t/test.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl6
 use v6;
-BEGIN { @*INC.unshift: '../lib'; }
+use lib '../lib';
 
 use HTML::Strip;
 use Test;


### PR DESCRIPTION
@*INC is no longer available. `use lib` is the new way.